### PR TITLE
feat: Add initial unit tests for core tools and nodes

### DIFF
--- a/tests/test_crawler_node.py
+++ b/tests/test_crawler_node.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from nodes.crawler_node import CrawlerNode
+from tools.crawler import WebCrawler # Needed for isinstance check if not mocking __init__
+
+class TestCrawlerNode(unittest.TestCase):
+
+    def test_prep_method(self):
+        node = CrawlerNode()
+
+        # Scenario 1: URL in shared
+        shared_s1 = {"url": "http://example.com"}
+        self.assertEqual(node.prep(shared_s1), "http://example.com")
+
+        # Scenario 2: URL not in shared
+        shared_s2 = {}
+        self.assertEqual(node.prep(shared_s2), "") # As per current implementation
+
+        # Scenario 3: shared is None
+        self.assertIsNone(node.prep(None)) # .get on None raises AttributeError, but current code is `shared.get("url", "")`
+
+        # Scenario 3b: key "url" exists but is None
+        shared_s3b = {"url": None}
+        self.assertIsNone(node.prep(shared_s3b))
+
+
+    @patch('nodes.crawler_node.WebCrawler') # Patch WebCrawler in the crawler_node module
+    def test_exec_method(self, MockWebCrawler):
+        node = CrawlerNode(max_pages=10)
+
+        # Scenario 1: Valid URL provided
+        mock_crawler_instance = MockWebCrawler.return_value
+        mock_crawl_results = [{"url": "http://example.com", "title": "Test"}]
+        mock_crawler_instance.crawl.return_value = mock_crawl_results
+        
+        url_s1 = "http://example.com"
+        result_s1 = node.exec(url_s1)
+        
+        MockWebCrawler.assert_called_once_with(base_url=url_s1, max_pages=10)
+        mock_crawler_instance.crawl.assert_called_once_with()
+        self.assertEqual(result_s1, mock_crawl_results)
+
+        MockWebCrawler.reset_mock() # Reset mock for the next scenario
+
+        # Scenario 2: Empty URL provided
+        result_s2_empty = node.exec("")
+        self.assertEqual(result_s2_empty, [])
+        MockWebCrawler.assert_not_called() # Should not be called for empty URL
+
+        # Scenario 2b: None URL provided
+        result_s2_none = node.exec(None)
+        self.assertEqual(result_s2_none, [])
+        MockWebCrawler.assert_not_called() # Should not be called for None URL
+
+        MockWebCrawler.reset_mock()
+
+        # Scenario 3: WebCrawler.crawl raises an exception
+        mock_crawler_instance_s3 = MockWebCrawler.return_value
+        mock_crawler_instance_s3.crawl.side_effect = Exception("Crawl failed")
+        
+        url_s3 = "http://anotherexample.com"
+        with self.assertRaises(Exception) as context:
+            node.exec(url_s3)
+        self.assertTrue("Crawl failed" in str(context.exception))
+        MockWebCrawler.assert_called_once_with(base_url=url_s3, max_pages=10)
+        mock_crawler_instance_s3.crawl.assert_called_once_with()
+
+
+    def test_post_method(self):
+        node = CrawlerNode()
+        shared = {}
+        prep_res_url = "http://example.com" # Not directly used by post, but part of the flow
+        exec_res_crawl_data = [{"url": "http://example.com", "title": "Test Page"}]
+
+        result = node.post(shared, prep_res_url, exec_res_crawl_data)
+
+        self.assertEqual(shared.get("crawl_results"), exec_res_crawl_data)
+        self.assertEqual(result, "default")
+
+        # Test with pre-existing shared data (should be overwritten)
+        shared_preexisting = {"other_key": "other_value", "crawl_results": "old_data"}
+        exec_res_new_data = [{"url": "http://new.com", "title": "New Page"}]
+        result_new = node.post(shared_preexisting, "http://new.com", exec_res_new_data)
+        self.assertEqual(shared_preexisting.get("crawl_results"), exec_res_new_data)
+        self.assertEqual(shared_preexisting.get("other_key"), "other_value") # Ensure other keys are not lost
+        self.assertEqual(result_new, "default")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_crawler_tool.py
+++ b/tests/test_crawler_tool.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tools.crawler import WebCrawler
+import requests
+
+class TestWebCrawler(unittest.TestCase):
+    def setUp(self):
+        self.crawler = WebCrawler(base_url="http://example.com")
+
+    def test_is_valid_url(self):
+        # Test cases for is_valid_url
+        self.assertTrue(self.crawler.is_valid_url("http://example.com/path"))
+        self.assertFalse(self.crawler.is_valid_url("http://sub.example.com/path"))
+        self.assertTrue(self.crawler.is_valid_url("https://example.com/path")) # Scheme difference
+        self.assertFalse(self.crawler.is_valid_url("http://another.com/path"))
+        self.assertFalse(self.crawler.is_valid_url("ftp://example.com/path")) # Different scheme
+        self.assertTrue(self.crawler.is_valid_url("http://example.com")) # Exactly base url
+        self.assertTrue(self.crawler.is_valid_url("http://example.com/")) # Base url with slash
+        self.assertFalse(self.crawler.is_valid_url("http://example.com:8080/path")) # Different port
+
+    @patch('tools.crawler.requests.get')
+    @patch('tools.crawler.BeautifulSoup')
+    def test_extract_page_content(self, mock_beautiful_soup, mock_requests_get):
+        # Mock successful response
+        mock_response = MagicMock()
+        mock_response.text = """
+        <html>
+            <head><title>Test Title</title></head>
+            <body>
+                <p>Some text here.</p>
+                <a href="/path1">Link 1</a>
+                <a href="http://example.com/path2">Link 2</a>
+                <a href="http://sub.example.com/path3">External Link</a>
+                <a href="https://example.com/path4">Secure Link</a>
+            </body>
+        </html>
+        """
+        mock_requests_get.return_value = mock_response
+
+        mock_soup = MagicMock()
+        mock_soup.title.string = "Test Title"
+        mock_soup.get_text.return_value = "Test Title Some text here. Link 1 Link 2 External Link Secure Link"
+        
+        # Mock find_all for links
+        mock_a_tag_1 = MagicMock()
+        mock_a_tag_1.get.return_value = "/path1"
+        mock_a_tag_2 = MagicMock()
+        mock_a_tag_2.get.return_value = "http://example.com/path2"
+        mock_a_tag_3 = MagicMock()
+        mock_a_tag_3.get.return_value = "http://sub.example.com/path3" # Invalid
+        mock_a_tag_4 = MagicMock()
+        mock_a_tag_4.get.return_value = "https://example.com/path4" # Valid (scheme difference)
+
+        mock_soup.find_all.return_value = [mock_a_tag_1, mock_a_tag_2, mock_a_tag_3, mock_a_tag_4]
+        mock_beautiful_soup.return_value = mock_soup
+
+        result = self.crawler.extract_page_content("http://example.com/testpage")
+        
+        self.assertIsNotNone(result)
+        self.assertEqual(result['title'], "Test Title")
+        self.assertEqual(result['text'], "Test Title Some text here. Link 1 Link 2 External Link Secure Link")
+        self.assertIn("http://example.com/path1", result['links'])
+        self.assertIn("http://example.com/path2", result['links'])
+        self.assertNotIn("http://sub.example.com/path3", result['links']) # External link
+        self.assertIn("https://example.com/path4", result['links']) # Scheme difference but valid domain
+        mock_requests_get.assert_called_once_with("http://example.com/testpage", timeout=5)
+        mock_beautiful_soup.assert_called_once_with(mock_response.text, 'html.parser')
+
+        # Test no title
+        mock_soup.title = None
+        result_no_title = self.crawler.extract_page_content("http://example.com/notitle")
+        self.assertIsNotNone(result_no_title)
+        self.assertIsNone(result_no_title['title'])
+
+        # Test no links
+        mock_soup.find_all.return_value = []
+        result_no_links = self.crawler.extract_page_content("http://example.com/nolinks")
+        self.assertIsNotNone(result_no_links)
+        self.assertEqual(result_no_links['links'], [])
+        
+        # Test requests.get raising an exception
+        mock_requests_get.side_effect = requests.exceptions.RequestException("Test error")
+        with patch('tools.crawler.logging.error') as mock_logging_error:
+            result_exception = self.crawler.extract_page_content("http://example.com/errorpage")
+            self.assertIsNone(result_exception)
+            mock_logging_error.assert_called_once()
+
+    @patch('tools.crawler.WebCrawler.extract_page_content')
+    def test_crawl(self, mock_extract_page_content):
+        # Scenario 1: extract_page_content returns content with links
+        mock_extract_page_content.side_effect = [
+            {'title': 'Page 1', 'text': 'Text 1', 'links': ['http://example.com/page2']},
+            {'title': 'Page 2', 'text': 'Text 2', 'links': []}
+        ]
+        results = self.crawler.crawl(max_pages=2)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]['title'], 'Page 1')
+        self.assertEqual(results[1]['title'], 'Page 2')
+        self.assertIn('http://example.com', self.crawler.visited)
+        self.assertIn('http://example.com/page2', self.crawler.visited)
+        self.assertEqual(mock_extract_page_content.call_count, 2)
+        mock_extract_page_content.assert_any_call('http://example.com')
+        mock_extract_page_content.assert_any_call('http://example.com/page2')
+
+        # Reset visited for next scenario
+        self.crawler.visited = set()
+        mock_extract_page_content.reset_mock()
+
+        # Scenario 2: extract_page_content returns content with no new links
+        mock_extract_page_content.side_effect = [
+            {'title': 'Page 1', 'text': 'Text 1', 'links': ['http://example.com']} # Link to itself
+        ]
+        results = self.crawler.crawl(max_pages=5) # max_pages is high, but should stop after 1
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['title'], 'Page 1')
+        self.assertIn('http://example.com', self.crawler.visited)
+        mock_extract_page_content.assert_called_once_with('http://example.com')
+        
+        self.crawler.visited = set()
+        mock_extract_page_content.reset_mock()
+
+        # Scenario 3: extract_page_content returns None for some URLs
+        mock_extract_page_content.side_effect = [
+            {'title': 'Page 1', 'text': 'Text 1', 'links': ['http://example.com/errorpage', 'http://example.com/page2']},
+            None, # Simulating error on /errorpage
+            {'title': 'Page 2', 'text': 'Text 2', 'links': []}
+        ]
+        results = self.crawler.crawl(max_pages=3)
+        self.assertEqual(len(results), 2) # Page 1 and Page 2, errorpage is skipped
+        self.assertEqual(results[0]['title'], 'Page 1')
+        self.assertEqual(results[1]['title'], 'Page 2')
+        self.assertIn('http://example.com', self.crawler.visited)
+        self.assertIn('http://example.com/errorpage', self.crawler.visited) # Visited, but no content
+        self.assertIn('http://example.com/page2', self.crawler.visited)
+        self.assertEqual(mock_extract_page_content.call_count, 3)
+        mock_extract_page_content.assert_any_call('http://example.com')
+        mock_extract_page_content.assert_any_call('http://example.com/errorpage')
+        mock_extract_page_content.assert_any_call('http://example.com/page2')
+
+        self.crawler.visited = set()
+        mock_extract_page_content.reset_mock()
+
+        # Scenario 4: Test max_pages limit
+        mock_extract_page_content.side_effect = [
+            {'title': 'Page 1', 'text': 'Text 1', 'links': ['http://example.com/page2']},
+            {'title': 'Page 2', 'text': 'Text 2', 'links': ['http://example.com/page3']},
+            # Should not reach page 3
+        ]
+        results = self.crawler.crawl(max_pages=1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['title'], 'Page 1')
+        self.assertIn('http://example.com', self.crawler.visited)
+        self.assertNotIn('http://example.com/page2', self.crawler.visited) # Not visited due to max_pages
+        mock_extract_page_content.assert_called_once_with('http://example.com')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mcp_nodes.py
+++ b/tests/test_mcp_nodes.py
@@ -1,0 +1,140 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import logging
+from nodes.mcp_nodes import GetToolsNode
+
+class TestGetToolsNode(unittest.TestCase):
+
+    def test_prep_method(self):
+        node = GetToolsNode()
+
+        # Scenario 1: question in shared
+        shared_s1 = {"question": "What is the weather?"}
+        self.assertEqual(node.prep(shared_s1), "What is the weather?")
+
+        # Scenario 2: question not in shared
+        shared_s2 = {}
+        self.assertIsNone(node.prep(shared_s2)) # Default for .get if key not found is None
+
+        # Scenario 3: question is None in shared
+        shared_s3 = {"question": None}
+        self.assertIsNone(node.prep(shared_s3))
+
+    @patch('nodes.mcp_nodes.get_tools')
+    def test_exec_method(self, mock_get_tools):
+        node = GetToolsNode()
+
+        # Scenario 1: get_tools returns valid tool data
+        tool_data_s1 = [{
+            "tool": {"name": "tool1", "description": "desc1", "inputSchema": {"properties": {"param1": {"type": "string"}}, "required": ["param1"]}},
+            "server_name": "server1"
+        }]
+        mock_get_tools.return_value = tool_data_s1
+        
+        result_s1 = node.exec("some question")
+        
+        mock_get_tools.assert_called_once_with("some question")
+        self.assertEqual(result_s1, tool_data_s1)
+
+        mock_get_tools.reset_mock()
+
+        # Scenario 2: get_tools returns an empty list
+        mock_get_tools.return_value = []
+        result_s2 = node.exec("some question")
+        self.assertEqual(result_s2, [])
+        mock_get_tools.assert_called_once_with("some question")
+
+        mock_get_tools.reset_mock()
+
+        # Scenario 3: get_tools raises an exception
+        mock_get_tools.side_effect = Exception("API Error")
+        with self.assertLogs(logger='nodes.mcp_nodes', level='ERROR') as cm:
+            result_s3 = node.exec("some question")
+        self.assertEqual(result_s3, [])
+        self.assertIn("Error in GetToolsNode.exec: API Error", cm.output[0])
+        mock_get_tools.assert_called_once_with("some question")
+
+    def test_post_method(self):
+        node = GetToolsNode()
+        prep_res = "some question"
+
+        # Scenario 1: exec_res is a list of valid tool data
+        exec_res_s1 = [
+            {"tool": {"name": "tool1", "description": "desc1", "inputSchema": {"properties": {"param1": {"type": "string", "description": "Param 1 desc"}}, "required": ["param1"]}}, "server_name": "server1"},
+            {"tool": {"name": "tool2", "description": "desc2", "inputSchema": {"properties": {"param2": {"type": "integer"}}, "required": []}}, "server_name": "server2"} # param2 is optional
+        ]
+        shared_s1 = {}
+        result_val_s1 = node.post(shared_s1, prep_res, exec_res_s1)
+
+        self.assertEqual(shared_s1["tools_with_server_info"], exec_res_s1)
+        expected_tool_map_s1 = {
+            "tool1": (exec_res_s1[0]["tool"], "server1"),
+            "tool2": (exec_res_s1[1]["tool"], "server2")
+        }
+        self.assertEqual(shared_s1["tool_map"], expected_tool_map_s1)
+        
+        expected_prompt_s1_lines = [
+            "Server Name: server1",
+            "Tool Name: tool1",
+            "Tool Description: desc1",
+            "Parameters:",
+            "  param1 (string): Param 1 desc (Required)",
+            "Server Name: server2",
+            "Tool Name: tool2",
+            "Tool Description: desc2",
+            "Parameters:",
+            "  param2 (integer): (Optional)" # No description for param2
+        ]
+        for line in expected_prompt_s1_lines:
+            self.assertIn(line, shared_s1["tool_info_for_prompt"])
+        self.assertEqual(result_val_s1, "decide")
+
+        # Scenario 2: exec_res is an empty list
+        exec_res_s2 = []
+        shared_s2 = {}
+        result_val_s2 = node.post(shared_s2, prep_res, exec_res_s2)
+
+        self.assertEqual(shared_s2["tools_with_server_info"], [])
+        self.assertEqual(shared_s2["tool_map"], {})
+        self.assertEqual(shared_s2["tool_info_for_prompt"], "") # Current behavior is empty string
+        self.assertEqual(result_val_s2, "decide")
+
+        # Scenario 3: Tool data has missing fields
+        exec_res_s3 = [
+            {"tool": {"name": "tool_no_schema", "description": "desc_no_schema"}, "server_name": "server3"}, # No inputSchema
+            {"tool": {"name": "tool_no_props", "description": "desc_no_props", "inputSchema": {}}, "server_name": "server4"}, # inputSchema but no properties
+            {"tool": {"name": "tool_no_required", "description": "desc_no_req", "inputSchema": {"properties": {"p1": {"type": "string"}}}}, "server_name": "server5"} # No 'required' array
+        ]
+        shared_s3 = {}
+        result_val_s3 = node.post(shared_s3, prep_res, exec_res_s3)
+
+        self.assertEqual(shared_s3["tool_map"]["tool_no_schema"], (exec_res_s3[0]["tool"], "server3"))
+        self.assertEqual(shared_s3["tool_map"]["tool_no_props"], (exec_res_s3[1]["tool"], "server4"))
+        self.assertEqual(shared_s3["tool_map"]["tool_no_required"], (exec_res_s3[2]["tool"], "server5"))
+
+        prompt_s3 = shared_s3["tool_info_for_prompt"]
+        self.assertIn("Server Name: server3\nTool Name: tool_no_schema\nTool Description: desc_no_schema\nParameters:\n  No parameters available.", prompt_s3)
+        self.assertIn("Server Name: server4\nTool Name: tool_no_props\nTool Description: desc_no_props\nParameters:\n  No parameters available.", prompt_s3)
+        self.assertIn("Server Name: server5\nTool Name: tool_no_required\nTool Description: desc_no_req\nParameters:\n  p1 (string): (Optional)", prompt_s3) # p1 is optional by default if not in 'required'
+        self.assertEqual(result_val_s3, "decide")
+
+        # Scenario 4: Tool data uses dict access
+        tool_dict_s4 = {"name": "dict_tool", "description": "dict_desc", "inputSchema": {"properties": {"p1": {"type": "int", "description": "Dict Param 1"}}, "required": []}}
+        exec_res_s4 = [{"tool": tool_dict_s4, "server_name": "server_dict"}]
+        shared_s4 = {}
+        result_val_s4 = node.post(shared_s4, prep_res, exec_res_s4)
+
+        self.assertEqual(shared_s4["tool_map"]["dict_tool"], (tool_dict_s4, "server_dict"))
+        expected_prompt_s4_lines = [
+            "Server Name: server_dict",
+            "Tool Name: dict_tool",
+            "Tool Description: dict_desc",
+            "Parameters:",
+            "  p1 (int): Dict Param 1 (Optional)"
+        ]
+        for line in expected_prompt_s4_lines:
+            self.assertIn(line, shared_s4["tool_info_for_prompt"])
+        self.assertEqual(result_val_s4, "decide")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parser_node.py
+++ b/tests/test_parser_node.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from nodes.parser_node import ParserNode
+
+class TestParserNode(unittest.TestCase):
+
+    def test_prep_method(self):
+        node = ParserNode()
+
+        # Scenario 1: crawl_results in shared
+        shared_s1 = {"crawl_results": [{"text": "some text"}]}
+        self.assertEqual(node.prep(shared_s1), [{"text": "some text"}])
+
+        # Scenario 2: crawl_results not in shared
+        shared_s2 = {}
+        self.assertEqual(node.prep(shared_s2), []) # As per shared.get("crawl_results", [])
+
+        # Scenario 3: crawl_results is None in shared
+        shared_s3 = {"crawl_results": None}
+        self.assertIsNone(node.prep(shared_s3))
+
+    @patch('nodes.parser_node.analyze_site') # Patch analyze_site in the parser_node module
+    def test_exec_method(self, mock_analyze_site):
+        node = ParserNode()
+
+        # Scenario 1: Valid crawl_results provided
+        mock_crawl_data_s1 = [{"text": "text1"}, {"text": "text2"}]
+        mock_analysis_results_s1 = [{"analysis": "analysis1"}, {"analysis": "analysis2"}]
+        mock_analyze_site.return_value = mock_analysis_results_s1
+        
+        result_s1 = node.exec(mock_crawl_data_s1)
+        
+        mock_analyze_site.assert_called_once_with(mock_crawl_data_s1)
+        self.assertEqual(result_s1, mock_analysis_results_s1)
+
+        mock_analyze_site.reset_mock()
+
+        # Scenario 2: Empty or None crawl_results provided
+        result_s2_empty = node.exec([])
+        self.assertEqual(result_s2_empty, [])
+        mock_analyze_site.assert_not_called()
+
+        result_s2_none = node.exec(None)
+        self.assertEqual(result_s2_none, [])
+        mock_analyze_site.assert_not_called()
+        
+        mock_analyze_site.reset_mock()
+
+        # Scenario 3: analyze_site raises an exception
+        mock_crawl_data_s3 = [{"text": "text_for_exception"}]
+        mock_analyze_site.side_effect = Exception("Analysis failed")
+        
+        with self.assertRaises(Exception) as context:
+            node.exec(mock_crawl_data_s3)
+        self.assertTrue("Analysis failed" in str(context.exception))
+        mock_analyze_site.assert_called_once_with(mock_crawl_data_s3)
+
+    def test_post_method(self):
+        node = ParserNode()
+        shared = {}
+        prep_res_crawl_data = [{"text": "some text"}] # Not directly used by post, but part of the flow
+        exec_res_analysis_data = [{"analysis": "analysis1"}]
+
+        result = node.post(shared, prep_res_crawl_data, exec_res_analysis_data)
+
+        self.assertEqual(shared.get("analyze_results"), exec_res_analysis_data)
+        self.assertEqual(result, "default")
+
+        # Test with pre-existing shared data (should be overwritten for "analyze_results")
+        shared_preexisting = {"other_key": "other_value", "analyze_results": "old_analysis"}
+        exec_res_new_analysis_data = [{"analysis": "new_analysis"}]
+        result_new = node.post(shared_preexisting, prep_res_crawl_data, exec_res_new_analysis_data)
+        
+        self.assertEqual(shared_preexisting.get("analyze_results"), exec_res_new_analysis_data)
+        self.assertEqual(shared_preexisting.get("other_key"), "other_value") # Ensure other keys are not lost
+        self.assertEqual(result_new, "default")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parser_tool.py
+++ b/tests/test_parser_tool.py
@@ -1,0 +1,143 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from tools.parser import analyze_content, analyze_site
+import yaml # For creating valid/invalid YAML scenarios
+import logging
+
+class TestParserTool(unittest.TestCase):
+
+    @patch('tools.parser.call_llm')
+    def test_analyze_content(self, mock_call_llm):
+        # Scenario 1: Successful LLM call, valid YAML
+        valid_yaml_str = """
+```yaml
+summary: "This is a test summary."
+topics:
+  - "topic1"
+  - "topic2"
+content_type: "article"
+```
+"""
+        mock_call_llm.return_value = valid_yaml_str
+        expected_output_s1 = {
+            "summary": "This is a test summary.",
+            "topics": ["topic1", "topic2"],
+            "content_type": "article"
+        }
+        result_s1 = analyze_content("Sample text content")
+        self.assertEqual(result_s1, expected_output_s1)
+        mock_call_llm.assert_called_once()
+
+        mock_call_llm.reset_mock()
+
+        # Scenario 2: Successful LLM call, invalid YAML/missing keys
+        invalid_yaml_str_missing_key = """
+```yaml
+topics:
+  - "topic1"
+content_type: "blog"
+```
+"""
+        mock_call_llm.return_value = invalid_yaml_str_missing_key
+        error_output = {"summary": "Error analyzing content", "topics": [], "content_type": "unknown"}
+        with self.assertLogs(logger='tools.parser', level='ERROR') as cm_s2_missing:
+            result_s2_missing = analyze_content("Sample text content")
+            self.assertEqual(result_s2_missing, error_output)
+        self.assertIn("Error parsing LLM response YAML", cm_s2_missing.output[0]) # or "Missing key 'summary' in parsed YAML"
+        mock_call_llm.assert_called_once()
+        mock_call_llm.reset_mock()
+
+        malformed_yaml_str = """
+```yaml
+summary: "Test"
+topics: - topic1
+  - topic2 # Incorrect indentation
+content_type: "news"
+```
+"""
+        mock_call_llm.return_value = malformed_yaml_str
+        with self.assertLogs(logger='tools.parser', level='ERROR') as cm_s2_malformed:
+            result_s2_malformed = analyze_content("Sample text content")
+            self.assertEqual(result_s2_malformed, error_output)
+        self.assertIn("Error parsing LLM response YAML", cm_s2_malformed.output[0])
+        mock_call_llm.assert_called_once()
+        mock_call_llm.reset_mock()
+
+        # Scenario 3: LLM call raises an exception
+        mock_call_llm.side_effect = Exception("LLM processing error")
+        with self.assertLogs(logger='tools.parser', level='ERROR') as cm_s3:
+            result_s3 = analyze_content("Sample text content")
+            self.assertEqual(result_s3, error_output)
+        self.assertIn("LLM call failed: LLM processing error", cm_s3.output[0])
+        mock_call_llm.assert_called_once()
+        mock_call_llm.reset_mock()
+        mock_call_llm.side_effect = None # Reset side_effect
+
+        # Scenario 4: LLM response without YAML block
+        no_yaml_block_str = "This is a response without any YAML."
+        mock_call_llm.return_value = no_yaml_block_str
+        with self.assertLogs(logger='tools.parser', level='ERROR') as cm_s4:
+            result_s4 = analyze_content("Sample text content")
+            self.assertEqual(result_s4, error_output)
+        self.assertIn("Could not find YAML block in LLM response", cm_s4.output[0])
+        mock_call_llm.assert_called_once()
+
+    @patch('tools.parser.analyze_content')
+    def test_analyze_site(self, mock_analyze_content):
+        # Scenario 1: List of valid crawl results
+        crawl_data_s1 = [
+            {'title': 'Page 1', 'url': 'url1', 'text': 'text1 about topicA'},
+            {'title': 'Page 2', 'url': 'url2', 'text': 'text2 about topicB'}
+        ]
+        analysis_result_1 = {"summary": "Summary 1", "topics": ["topicA"], "content_type": "article"}
+        analysis_result_2 = {"summary": "Summary 2", "topics": ["topicB"], "content_type": "blog"}
+        
+        mock_analyze_content.side_effect = [analysis_result_1, analysis_result_2]
+        
+        expected_output_s1 = [
+            {'title': 'Page 1', 'url': 'url1', 'text': 'text1 about topicA', 'analysis': analysis_result_1},
+            {'title': 'Page 2', 'url': 'url2', 'text': 'text2 about topicB', 'analysis': analysis_result_2}
+        ]
+        
+        result_s1 = analyze_site(crawl_data_s1)
+        self.assertEqual(result_s1, expected_output_s1)
+        self.assertEqual(mock_analyze_content.call_count, 2)
+        mock_analyze_content.assert_any_call('text1 about topicA')
+        mock_analyze_content.assert_any_call('text2 about topicB')
+
+        mock_analyze_content.reset_mock()
+        mock_analyze_content.side_effect = None
+
+        # Scenario 2: Empty crawl results list
+        result_s2 = analyze_site([])
+        self.assertEqual(result_s2, [])
+        mock_analyze_content.assert_not_called()
+
+        # Scenario 3: Crawl results with missing 'text' or None items
+        crawl_data_s3 = [
+            {'title': 'Page 1', 'url': 'url1', 'text': 'text1 valid'},
+            None, # Should be skipped
+            {'title': 'Page 3', 'url': 'url3'}, # Missing 'text'
+            {'title': 'Page 4', 'url': 'url4', 'text': 'text4 valid'}
+        ]
+        analysis_result_3_1 = {"summary": "Summary 3_1", "topics": ["valid1"], "content_type": "news"}
+        analysis_result_3_4 = {"summary": "Summary 3_4", "topics": ["valid4"], "content_type": "other"}
+        
+        # analyze_content will only be called for items with 'text'
+        mock_analyze_content.side_effect = [analysis_result_3_1, analysis_result_3_4]
+        
+        expected_output_s3 = [
+            {'title': 'Page 1', 'url': 'url1', 'text': 'text1 valid', 'analysis': analysis_result_3_1},
+            # None is skipped
+            {'title': 'Page 3', 'url': 'url3'}, # Item without 'text' is passed through without 'analysis'
+            {'title': 'Page 4', 'url': 'url4', 'text': 'text4 valid', 'analysis': analysis_result_3_4}
+        ]
+        
+        result_s3 = analyze_site(crawl_data_s3)
+        self.assertEqual(result_s3, expected_output_s3)
+        self.assertEqual(mock_analyze_content.call_count, 2)
+        mock_analyze_content.assert_any_call('text1 valid')
+        mock_analyze_content.assert_any_call('text4 valid')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_search_answer_nodes.py
+++ b/tests/test_search_answer_nodes.py
@@ -1,0 +1,434 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+from nodes.search_answer_nodes import SearchNode # Assuming AnswerNode is in the same file
+
+class TestSearchNode(unittest.TestCase):
+
+    # Test __init__ method (API Key Handling)
+    @patch.dict(os.environ, {"TAVILY_API_KEY": "env_key_for_searchnode"})
+    def test_init_with_api_key_env(self):
+        node = SearchNode()
+        self.assertEqual(node.api_key, "env_key_for_searchnode")
+
+    @patch.dict(os.environ, {}, clear=True) # Ensure TAVILY_API_KEY is not set
+    def test_init_without_api_key_env(self):
+        # It seems the __init__ method of SearchNode doesn't explicitly check for the API key
+        # or raise an error if it's missing, it just sets self.api_key = os.getenv("TAVILY_API_KEY")
+        # which would be None if not set. The actual check happens in the tavily_search tool or TavilySearchTool class.
+        node = SearchNode()
+        self.assertIsNone(node.api_key) # os.getenv returns None if key doesn't exist
+
+    # Test prep method
+    def test_prep_method(self):
+        # Assuming TAVILY_API_KEY is not needed for prep
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "dummy_key"}): # Ensure api_key is not None for init
+            node = SearchNode()
+
+        # Scenario 1: question in shared
+        shared_s1 = {"question": "What is AI?"}
+        self.assertEqual(node.prep(shared_s1), "What is AI?")
+
+        # Scenario 2: question not in shared
+        shared_s2 = {}
+        self.assertEqual(node.prep(shared_s2), "")
+
+        # Scenario 3: shared is None
+        self.assertEqual(node.prep(None), "") # shared.get("question", "") if shared is None would error, current code is `shared.get("question", "")`
+
+        # Scenario 4: question key exists but is None
+        shared_s4 = {"question": None}
+        self.assertIsNone(node.prep(shared_s4))
+
+
+    @patch('nodes.search_answer_nodes.tavily_search')
+    def test_exec_method(self, mock_tavily_search):
+        # Scenario 1: Valid question provided
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "test_api_key_exec"}):
+            node_s1 = SearchNode() # api_key will be set via mocked env
+        
+        question_s1 = "What is the capital of France?"
+        mock_search_result_s1 = "Search results: Paris is the capital of France."
+        mock_tavily_search.return_value = mock_search_result_s1
+        
+        result_s1 = node_s1.exec(question_s1)
+        
+        mock_tavily_search.assert_called_once_with(question_s1, api_key="test_api_key_exec", num_results=3)
+        self.assertEqual(result_s1, mock_search_result_s1)
+
+        mock_tavily_search.reset_mock()
+
+        # Ensure node for S2 and S3 has an api_key for consistency, though not strictly needed if tavily_search isn't called
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "dummy_key_s2_s3"}):
+            node_s2_s3 = SearchNode()
+
+        # Scenario 2: Empty or None question provided
+        result_s2_empty = node_s2_s3.exec("")
+        self.assertEqual(result_s2_empty, "")
+        mock_tavily_search.assert_not_called()
+
+        result_s2_none = node_s2_s3.exec(None)
+        self.assertEqual(result_s2_none, "")
+        mock_tavily_search.assert_not_called()
+        
+        mock_tavily_search.reset_mock()
+
+        # Scenario 3: tavily_search raises an exception
+        question_s3 = "This will cause an error"
+        mock_tavily_search.side_effect = Exception("Tavily API Error")
+        
+        # We need a node instance for this test that has an API key
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "key_for_exception_test"}):
+            node_s3_exception = SearchNode()
+
+        with self.assertRaises(Exception) as context:
+            node_s3_exception.exec(question_s3)
+        self.assertTrue("Tavily API Error" in str(context.exception))
+        mock_tavily_search.assert_called_once_with(question_s3, api_key="key_for_exception_test", num_results=3)
+
+
+    def test_post_method(self):
+        # Assuming TAVILY_API_KEY is not needed for post
+        with patch.dict(os.environ, {"TAVILY_API_KEY": "dummy_key"}): # Ensure api_key is not None for init
+            node = SearchNode()
+
+        shared = {}
+        prep_res_question = "What is the weather like?" # Not directly used by post
+        exec_res_search_output = "Sunny with a chance of clouds."
+
+        result = node.post(shared, prep_res_question, exec_res_search_output)
+
+        self.assertEqual(shared.get("search_result"), exec_res_search_output)
+        self.assertEqual(result, "default")
+
+        # Test with pre-existing shared data
+        shared_preexisting = {"other_key": "other_value", "search_result": "old_search_data"}
+        exec_res_new_search_output = "Rainy day."
+        result_new = node.post(shared_preexisting, prep_res_question, exec_res_new_search_output)
+        
+        self.assertEqual(shared_preexisting.get("search_result"), exec_res_new_search_output)
+        self.assertEqual(shared_preexisting.get("other_key"), "other_value") # Ensure other keys are preserved
+        self.assertEqual(result_new, "default")
+
+if __name__ == '__main__':
+    # This part is for local execution, will be removed by the testing framework
+    # Placeholder for AnswerNode tests if they were in the same file and needed to be run
+    # class TestAnswerNode(unittest.TestCase):
+    #     def test_placeholder(self):
+    #         self.assertTrue(True)
+
+# --- Tests for AnswerNode ---
+from nodes.search_answer_nodes import AnswerNode # Assuming AnswerNode is in the same file
+import logging # For checking logs in post method
+
+class TestAnswerNode(unittest.TestCase):
+
+    def test_prep_method(self):
+        node = AnswerNode()
+
+        # Scenario 1: With "thought" data
+        shared_s1 = {
+            "question": "User question?",
+            "thought": [
+                {"thought_number": 1, "thought": "Step 1 thought"},
+                {"thought": "Step 2 raw thought"} # Older format thought
+            ]
+        }
+        prompt_s1 = node.prep(shared_s1)
+        self.assertIn("User question?", prompt_s1)
+        self.assertIn("Thought Process Summary:", prompt_s1)
+        self.assertIn("Step 1: Step 1 thought", prompt_s1)
+        self.assertIn("Step 2: Step 2 raw thought", prompt_s1)
+        self.assertNotIn("Tool Execution Result:", prompt_s1)
+
+        # Scenario 2: Without "thought" data, with "question" and "tool_execution_result"
+        shared_s2 = {"question": "User question?", "tool_execution_result": "Tool output"}
+        prompt_s2 = node.prep(shared_s2)
+        self.assertIn("User question?", prompt_s2)
+        self.assertIn("Tool Execution Result:", prompt_s2)
+        self.assertIn("Tool output", prompt_s2)
+        self.assertNotIn("Thought Process Summary:", prompt_s2)
+
+        # Scenario 3: Without "thought", only "question"
+        shared_s3 = {"question": "User question?"}
+        prompt_s3 = node.prep(shared_s3)
+        self.assertIn("User question?", prompt_s3)
+        self.assertNotIn("Tool Execution Result:", prompt_s3) # or it might say "None" or "N/A"
+        self.assertNotIn("Thought Process Summary:", prompt_s3)
+        # Check for specific phrasing if only question is present
+        self.assertTrue(prompt_s3.startswith("Please provide a direct and concise answer to the following question based on the information provided.\nUser Question: User question?\nAnswer:"))
+
+
+        # Scenario 4: Without "thought", only "tool_execution_result"
+        shared_s4 = {"tool_execution_result": "Tool output"}
+        prompt_s4 = node.prep(shared_s4)
+        self.assertIn("Tool Execution Result:", prompt_s4)
+        self.assertIn("Tool output", prompt_s4)
+        self.assertNotIn("User Question:", prompt_s4) # or it might say "None" or "N/A"
+        self.assertNotIn("Thought Process Summary:", prompt_s4)
+        # Check for specific phrasing if only tool result is present
+        self.assertTrue(prompt_s4.startswith("Please provide a direct and concise answer based on the following tool execution result.\nTool Execution Result: Tool output\nAnswer:"))
+
+
+        # Scenario 5: Empty shared or missing relevant keys
+        shared_s5 = {}
+        prompt_s5 = node.prep(shared_s5)
+        # Based on the implementation, if both are empty, it will be:
+        # "Please provide a direct and concise answer to the following question based on the information provided.\nUser Question: \nTool Execution Result: \nAnswer:"
+        self.assertIn("User Question: \n", prompt_s5) # Empty question
+        self.assertIn("Tool Execution Result: \n", prompt_s5) # Empty tool result
+        self.assertNotIn("Thought Process Summary:", prompt_s5)
+
+
+    @patch('nodes.search_answer_nodes.stream_llm')
+    def test_exec_method(self, mock_stream_llm):
+        node = AnswerNode()
+
+        # Scenario 1: Successful stream_llm call
+        prompt_s1 = "Test prompt for exec"
+        mock_generator_s1 = iter(["Hello", " ", "World"])
+        mock_stream_llm.return_value = mock_generator_s1
+        
+        result_s1 = node.exec(prompt_s1)
+        
+        self.assertEqual(result_s1, mock_generator_s1) # exec should return the generator
+        mock_stream_llm.assert_called_once()
+        called_args, called_kwargs = mock_stream_llm.call_args
+        self.assertEqual(len(called_args[0]), 2) # messages list
+        self.assertEqual(called_args[0][0]["role"], "system")
+        self.assertEqual(called_args[0][1]["role"], "user")
+        self.assertEqual(called_args[0][1]["content"], prompt_s1)
+        self.assertIsNone(called_kwargs.get("model")) # model is optional in call_llm/stream_llm
+
+        mock_stream_llm.reset_mock()
+
+        # Scenario 2: stream_llm raises an exception
+        prompt_s2 = "Prompt that causes error"
+        mock_stream_llm.side_effect = Exception("LLM Stream Error")
+        
+        with self.assertRaises(Exception) as context:
+            node.exec(prompt_s2)
+        self.assertTrue("LLM Stream Error" in str(context.exception))
+        mock_stream_llm.assert_called_once() # Check it was called
+
+
+    def test_post_method(self):
+        node = AnswerNode()
+
+        # Scenario 1: Successful streaming aggregation
+        shared_s1 = {}
+        prep_res_s1 = "some prompt for scenario 1"
+        exec_res_s1 = iter(["Final", " ", "Answer", "."])
+        
+        result_s1 = node.post(shared_s1, prep_res_s1, exec_res_s1)
+        
+        self.assertEqual(shared_s1.get("answer"), "Final Answer.")
+        self.assertEqual(result_s1, "default")
+
+        # Scenario 2: Generator from exec_res raises an exception during iteration
+        shared_s2 = {}
+        prep_res_s2 = "some prompt for scenario 2"
+        
+        def error_generator():
+            yield "Part 1"
+            yield "Part 2"
+            raise Exception("Stream consumption error")
+
+        exec_res_s2 = error_generator()
+        
+        with patch.object(logging, 'error') as mock_log_error: # Check logging
+            result_s2 = node.post(shared_s2, prep_res_s2, exec_res_s2)
+        
+        self.assertIn("Part 1Part 2", shared_s2.get("answer"))
+        self.assertIn("Error during answer generation: Stream consumption error", shared_s2.get("answer"))
+        self.assertEqual(result_s2, "default")
+        mock_log_error.assert_called_once()
+        self.assertIn("Error consuming stream for AnswerNode: Stream consumption error", mock_log_error.call_args[0][0])
+
+# --- Tests for ThinkingNode ---
+from nodes.search_answer_nodes import ThinkingNode
+
+class TestThinkingNode(unittest.TestCase):
+
+    def test_prep_method(self):
+        node = ThinkingNode()
+
+        # Scenario 1: All relevant keys in shared
+        shared_s1 = {
+            "thoughtNumber": 2,
+            "totalThoughts": 5,
+            "branches": [{"thought_number": 1, "thought": "Initial thought"}],
+            "question": "What is the process?",
+            "nextThoughtNeeded": True,
+            "thoughtHistoryLength": 1
+        }
+        expected_prep_s1 = {
+            "thought_number": 2,
+            "total_thoughts": 5,
+            "branches": [{"thought_number": 1, "thought": "Initial thought"}],
+            "question": "What is the process?",
+            "next_thought_needed": True,
+            "thought_history_length": 1
+        }
+        self.assertEqual(node.prep(shared_s1), expected_prep_s1)
+
+        # Scenario 2: Some keys missing, relying on defaults
+        shared_s2 = {"question": "What if only question?"}
+        expected_prep_s2 = {
+            "thought_number": 1,
+            "total_thoughts": 3,
+            "branches": [],
+            "question": "What if only question?",
+            "next_thought_needed": True,
+            "thought_history_length": 0
+        }
+        self.assertEqual(node.prep(shared_s2), expected_prep_s2)
+
+        # Scenario 3: Empty shared dictionary
+        shared_s3 = {}
+        expected_prep_s3 = {
+            "thought_number": 1,
+            "total_thoughts": 3,
+            "branches": [],
+            "question": "",
+            "next_thought_needed": True,
+            "thought_history_length": 0
+        }
+        self.assertEqual(node.prep(shared_s3), expected_prep_s3)
+
+    @patch('nodes.search_answer_nodes.call_llm')
+    def test_exec_method(self, mock_call_llm):
+        node = ThinkingNode()
+
+        # Scenario 1: Continue thinking
+        context_s1 = {
+            "thought_number": 1,
+            "total_thoughts": 3,
+            "branches": [],
+            "question": "What is the first step?",
+            "next_thought_needed": True,
+            "thought_history_length": 0
+        }
+        mock_call_llm.return_value = "This is the first thought."
+        
+        result_s1 = node.exec(context_s1)
+        
+        mock_call_llm.assert_called_once()
+        prompt_s1 = mock_call_llm.call_args[0][0]
+        self.assertIn("You are a thought step in a multi-step thinking process.", prompt_s1)
+        self.assertIn(context_s1["question"], prompt_s1)
+        self.assertIn("【历史思考】\n无", prompt_s1) # No history yet
+        
+        self.assertTrue(result_s1["continue"])
+        self.assertEqual(len(result_s1["branches"]), 1)
+        self.assertEqual(result_s1["branches"][0]["thought_number"], 1)
+        self.assertEqual(result_s1["branches"][0]["thought"], "This is the first thought.")
+        self.assertTrue(result_s1["nextThoughtNeeded"])
+        self.assertEqual(result_s1["thoughtHistoryLength"], 1)
+
+        mock_call_llm.reset_mock()
+
+        # Scenario 2: Stop thinking (thought_number > total_thoughts)
+        context_s2 = {
+            "thought_number": 4,
+            "total_thoughts": 3,
+            "branches": [{"thought_number": 1, "thought": "T1"}, {"thought_number": 2, "thought": "T2"}, {"thought_number": 3, "thought": "T3"}],
+            "question": "What is the next step?",
+            "next_thought_needed": True, # This would be True from previous step
+            "thought_history_length": 3
+        }
+        result_s2 = node.exec(context_s2)
+        
+        mock_call_llm.assert_not_called()
+        self.assertFalse(result_s2["continue"])
+        self.assertEqual(result_s2["branches"], context_s2["branches"])
+        self.assertFalse(result_s2["nextThoughtNeeded"]) # Should be set to False when stopping
+        self.assertEqual(result_s2["thoughtHistoryLength"], context_s2["thought_history_length"])
+
+        mock_call_llm.reset_mock()
+
+        # Scenario 3: Stop thinking (nextThoughtNeeded is False)
+        context_s3 = {
+            "thought_number": 2,
+            "total_thoughts": 3,
+            "branches": [{"thought_number": 1, "thought": "T1"}],
+            "question": "What is the next step?",
+            "next_thought_needed": False,
+            "thought_history_length": 1
+        }
+        result_s3 = node.exec(context_s3)
+
+        mock_call_llm.assert_not_called()
+        self.assertFalse(result_s3["continue"])
+        self.assertEqual(result_s3["branches"], context_s3["branches"])
+        self.assertFalse(result_s3["nextThoughtNeeded"])
+        self.assertEqual(result_s3["thoughtHistoryLength"], context_s3["thought_history_length"])
+        
+        mock_call_llm.reset_mock()
+
+        # Scenario 4: Formatting of history in prompt
+        context_s4 = {
+            "thought_number": 3,
+            "total_thoughts": 3,
+            "branches": [
+                {"thought_number": 1, "thought": "First thought."}, # Dict style
+                "Second thought, direct string." # String style (older format)
+            ],
+            "question": "What is the third step?",
+            "next_thought_needed": True,
+            "thought_history_length": 2 # length of branches
+        }
+        mock_call_llm.return_value = "This is the third thought."
+        node.exec(context_s4)
+
+        mock_call_llm.assert_called_once()
+        prompt_s4 = mock_call_llm.call_args[0][0]
+        expected_history_s4 = "【历史思考】\n【第1步】First thought.\n【第2步】Second thought, direct string."
+        self.assertIn(expected_history_s4, prompt_s4)
+        self.assertIn(context_s4["question"], prompt_s4)
+
+
+    def test_post_method(self):
+        node = ThinkingNode()
+
+        # Scenario 1: exec_res indicates continue thinking
+        shared_s1 = {"thoughtNumber": 1, "totalThoughts": 3, "branches": [], "nextThoughtNeeded": False, "thoughtHistoryLength": 0}
+        # prep_res for ThinkingNode is a dict, not directly used by post in a way that needs complex mocking here
+        prep_res_s1 = {"thought_number": 1, "total_thoughts": 3, "branches": [], "question": "Q", "next_thought_needed": True, "thought_history_length": 0}
+        exec_res_s1 = {
+            "continue": True, 
+            "branches": [{"thought_number": 1, "thought": "new_thought"}], 
+            "nextThoughtNeeded": True, 
+            "thoughtHistoryLength": 1
+        }
+        
+        result_s1 = node.post(shared_s1, prep_res_s1, exec_res_s1)
+
+        self.assertEqual(shared_s1["branches"], exec_res_s1["branches"])
+        self.assertTrue(shared_s1["nextThoughtNeeded"])
+        self.assertEqual(shared_s1["thoughtHistoryLength"], 1)
+        self.assertEqual(shared_s1["thoughtNumber"], 2) # Incremented
+        self.assertEqual(result_s1, "continue")
+
+        # Scenario 2: exec_res indicates stop thinking
+        shared_s2 = {"thoughtNumber": 3, "totalThoughts": 3, "branches": [{"thought_number":1, "thought":"t1"}, {"thought_number":2, "thought":"t2"}], "nextThoughtNeeded": True, "thoughtHistoryLength": 2}
+        prep_res_s2 = {"thought_number": 3, "total_thoughts": 3, "branches": shared_s2["branches"], "question": "Q", "next_thought_needed": True, "thought_history_length": 2}
+        exec_res_s2 = {
+            "continue": False, 
+            "branches": [{"thought_number":1, "thought":"t1"}, {"thought_number":2, "thought":"t2"}, {"thought_number": 3, "thought": "final_thought"}], 
+            "nextThoughtNeeded": False, 
+            "thoughtHistoryLength": 3
+        }
+        
+        result_s2 = node.post(shared_s2, prep_res_s2, exec_res_s2)
+
+        self.assertEqual(shared_s2["branches"], exec_res_s2["branches"])
+        self.assertFalse(shared_s2["nextThoughtNeeded"])
+        self.assertEqual(shared_s2["thoughtHistoryLength"], 3)
+        self.assertEqual(shared_s2["thought"], exec_res_s2["branches"]) # 'thought' key gets all branches
+        self.assertEqual(shared_s2["thoughtNumber"], 3) # Not incremented as we stop
+        self.assertEqual(result_s2, "default")
+
+
+if __name__ == '__main__':    
+    unittest.main()

--- a/tests/test_tavily_tool.py
+++ b/tests/test_tavily_tool.py
@@ -1,0 +1,194 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import httpx # Import httpx for mocking
+from tools.tavily import TavilySearchTool, tavily_search
+import logging
+
+class TestTavilyTool(unittest.TestCase):
+
+    # Test TavilySearchTool.__init__
+    def test_init_with_api_key_direct(self):
+        tool = TavilySearchTool(api_key="direct_key")
+        self.assertEqual(tool.api_key, "direct_key")
+
+    @patch.dict(os.environ, {"TAVILY_API_KEY": "env_key"})
+    def test_init_with_api_key_env(self):
+        tool = TavilySearchTool()
+        self.assertEqual(tool.api_key, "env_key")
+
+    @patch.dict(os.environ, {}, clear=True) # Ensure TAVILY_API_KEY is not set
+    def test_init_no_api_key(self):
+        with self.assertRaises(ValueError) as context:
+            TavilySearchTool()
+        self.assertEqual(str(context.exception), "Tavily API key not provided. Set TAVILY_API_KEY environment variable or pass api_key.")
+
+    # Test TavilySearchTool.search
+    @patch('tools.tavily.httpx.post')
+    def test_search_successful_valid_response(self, mock_httpx_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {"title": "Result 1", "content": "Snippet 1", "url": "url1"},
+                {"title": "Result 2", "content": "Snippet 2", "url": "url2"},
+                {"title": "Result 3", "content": "Snippet 3", "url": "url3"}
+            ]
+        }
+        mock_httpx_post.return_value = mock_response
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0], {"title": "Result 1", "snippet": "Snippet 1", "link": "url1"})
+        mock_httpx_post.assert_called_once()
+        # print(mock_httpx_post.call_args[1]['json']) # For debugging the payload
+        self.assertEqual(mock_httpx_post.call_args[1]['json']['query'], "test query")
+
+        # Test num_results
+        results_limited = tool.search("test query", num_results=1)
+        self.assertEqual(len(results_limited), 1)
+        self.assertEqual(results_limited[0], {"title": "Result 1", "snippet": "Snippet 1", "link": "url1"})
+        # httpx.post is called again, check num_results in payload
+        self.assertEqual(mock_httpx_post.call_args[1]['json']['max_results'], 1)
+
+
+    @patch('tools.tavily.httpx.post')
+    def test_search_successful_empty_results(self, mock_httpx_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_httpx_post.return_value = mock_response
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(results, [])
+        mock_httpx_post.assert_called_once_with(
+            "https://api.tavily.com/search",
+            json={
+                "api_key": "test_key",
+                "query": "test query",
+                "search_depth": "basic",
+                "include_answer": False,
+                "include_images": False,
+                "include_raw_content": False,
+                "max_results": 5, # Default
+                "include_domains": [],
+                "exclude_domains": []
+            }
+        )
+
+    @patch('tools.tavily.httpx.post')
+    @patch('tools.tavily.logging.error')
+    def test_search_api_error_status_code(self, mock_logging_error, mock_httpx_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_httpx_post.return_value = mock_response
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(results, [])
+        mock_logging_error.assert_called_once_with("Tavily API error (500): Internal Server Error")
+
+    @patch('tools.tavily.httpx.post')
+    @patch('tools.tavily.logging.error')
+    def test_search_api_request_exception(self, mock_logging_error, mock_httpx_post):
+        mock_httpx_post.side_effect = httpx.RequestError("Network error")
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(results, [])
+        mock_logging_error.assert_called_once_with("Error calling Tavily API: Network error")
+
+    @patch('tools.tavily.httpx.post')
+    @patch('tools.tavily.logging.warning')
+    def test_search_api_response_missing_results(self, mock_logging_warning, mock_httpx_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": "no results here"} # Missing 'results' key
+        mock_httpx_post.return_value = mock_response
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(results, [])
+        mock_logging_warning.assert_called_once_with("Tavily API response missing 'results' key or 'results' is not a list.")
+
+    @patch('tools.tavily.httpx.post')
+    @patch('tools.tavily.logging.warning')
+    def test_search_api_response_malformed_item(self, mock_logging_warning, mock_httpx_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        # 'content' key is missing in the first item
+        mock_response.json.return_value = {
+            "results": [
+                {"title": "Result 1", "url": "url1"}, 
+                {"title": "Result 2", "content": "Snippet 2", "url": "url2"}
+            ]
+        }
+        mock_httpx_post.return_value = mock_response
+        
+        tool = TavilySearchTool(api_key="test_key")
+        results = tool.search("test query")
+        
+        self.assertEqual(len(results), 1) # Only the valid item should be returned
+        self.assertEqual(results[0], {"title": "Result 2", "snippet": "Snippet 2", "link": "url2"})
+        mock_logging_warning.assert_called_once_with("Skipping a result due to missing 'title', 'content', or 'url'.")
+
+
+    # Test tavily_search (wrapper function)
+    @patch('tools.tavily.TavilySearchTool')
+    def test_tavily_search_wrapper_successful(self, MockTavilySearchTool):
+        mock_search_instance = MockTavilySearchTool.return_value
+        mock_search_instance.search.return_value = [
+            {"title": "R1", "snippet": "S1", "link": "L1"},
+            {"title": "R2", "snippet": "S2", "link": "L2"}
+        ]
+        
+        expected_output = "搜索结果:\n[1] R1 (S1) - L1\n[2] R2 (S2) - L2"
+        result = tavily_search("test query", num_results=2)
+        
+        self.assertEqual(result, expected_output)
+        MockTavilySearchTool.assert_called_once() # API key handling implicitly tested by TavilySearchTool init
+        mock_search_instance.search.assert_called_once_with("test query", num_results=2)
+
+    @patch('tools.tavily.TavilySearchTool')
+    def test_tavily_search_wrapper_empty_results(self, MockTavilySearchTool):
+        mock_search_instance = MockTavilySearchTool.return_value
+        mock_search_instance.search.return_value = []
+        
+        expected_output = "未找到相关搜索结果。"
+        result = tavily_search("test query")
+        
+        self.assertEqual(result, expected_output)
+        mock_search_instance.search.assert_called_once_with("test query", num_results=3) # Default num_results
+
+    @patch('tools.tavily.TavilySearchTool')
+    def test_tavily_search_wrapper_search_exception(self, MockTavilySearchTool):
+        mock_search_instance = MockTavilySearchTool.return_value
+        mock_search_instance.search.side_effect = Exception("Search failed unexpectedly")
+        
+        expected_output = "Tavily 搜索异常: Search failed unexpectedly"
+        result = tavily_search("test query")
+        
+        self.assertEqual(result, expected_output)
+
+    @patch.dict(os.environ, {}, clear=True) # Ensure TAVILY_API_KEY is not set for this specific test
+    @patch('tools.tavily.TavilySearchTool') # Still mock the class to prevent actual API calls if init somehow passes
+    def test_tavily_search_wrapper_init_exception(self, MockTavilySearchTool):
+        # This tests if the ValueError from TavilySearchTool.__init__ (due to no API key)
+        # is caught by the wrapper.
+        MockTavilySearchTool.side_effect = ValueError("API key missing")
+
+        expected_output = "Tavily 搜索异常: API key missing"
+        result = tavily_search("test query")
+        self.assertEqual(result, expected_output)
+        MockTavilySearchTool.assert_called_once_with(api_key=None) # api_key is None by default in wrapper
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces unit tests for several core components of the application:

- Tools:
  - \`tools/crawler.py\` (WebCrawler class)
  - \`tools/parser.py\` (analyze_content, analyze_site)
  - \`tools/tavily.py\` (TavilySearchTool, tavily_search)

- Workflow Nodes:
  - \`nodes/crawler_node.py\` (CrawlerNode)
  - \`nodes/parser_node.py\` (ParserNode)
  - \`nodes/search_answer_nodes.py\` (SearchNode, ThinkingNode, AnswerNode)
  - \`nodes/mcp_nodes.py\` (GetToolsNode)

The tests cover various scenarios, including mocking external dependencies (LLMs, API calls), handling different input data, and verifying expected outputs and state changes within the shared context.